### PR TITLE
Add administrator panel & user support

### DIFF
--- a/app/Filament/Admin/Resources/AdministratorResource.php
+++ b/app/Filament/Admin/Resources/AdministratorResource.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Filament\Admin\Resources;
+
+use App\Filament\Admin\Resources\AdministratorResource\Pages;
+use App\Models\Administrator;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+/**
+ * An administrator is a class of user which has access to the 'admin' Filament panel.
+ * This user can pull reports and manage issues, manage users, manage tenants, and
+ * manage other resources in both central and tenant contexts, as authorized.
+ */
+class AdministratorResource extends Resource
+{
+    protected static ?string $model = Administrator::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                //
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                //
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index'  => Pages\ListAdministrators::route('/'),
+            'create' => Pages\CreateAdministrator::route('/create'),
+            'edit'   => Pages\EditAdministrator::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/AdministratorResource/Pages/CreateAdministrator.php
+++ b/app/Filament/Admin/Resources/AdministratorResource/Pages/CreateAdministrator.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Admin\Resources\AdministratorResource\Pages;
+
+use App\Filament\Admin\Resources\AdministratorResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateAdministrator extends CreateRecord
+{
+    protected static string $resource = AdministratorResource::class;
+}

--- a/app/Filament/Admin/Resources/AdministratorResource/Pages/EditAdministrator.php
+++ b/app/Filament/Admin/Resources/AdministratorResource/Pages/EditAdministrator.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Admin\Resources\AdministratorResource\Pages;
+
+use App\Filament\Admin\Resources\AdministratorResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditAdministrator extends EditRecord
+{
+    protected static string $resource = AdministratorResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/AdministratorResource/Pages/ListAdministrators.php
+++ b/app/Filament/Admin/Resources/AdministratorResource/Pages/ListAdministrators.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Admin\Resources\AdministratorResource\Pages;
+
+use App\Filament\Admin\Resources\AdministratorResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListAdministrators extends ListRecords
+{
+    protected static string $resource = AdministratorResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Models/Administrator.php
+++ b/app/Models/Administrator.php
@@ -2,10 +2,9 @@
 
 namespace App\Models;
 
-use App\Providers\Filament\OperatePanelProvider;
+use App\Providers\Filament\AdminPanelProvider;
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Panel;
-use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
@@ -13,13 +12,17 @@ use OwenIt\Auditing\Auditable;
 use Rappasoft\LaravelAuthenticationLog\Traits\AuthenticationLoggable;
 use Spatie\Permission\Traits\HasRoles;
 
-class Operator extends Authenticatable implements \OwenIt\Auditing\Contracts\Auditable, FilamentUser
+class Administrator extends Authenticatable implements \OwenIt\Auditing\Contracts\Auditable, FilamentUser
 {
-    use Auditable, AuthenticationLoggable, HasApiTokens, HasRoles, Notifiable;
+    use Auditable,
+        AuthenticationLoggable,
+        HasApiTokens,
+        HasRoles,
+        Notifiable;
 
     public function canAccessPanel(Panel $panel): bool
     {
-        return $panel->getId() === OperatePanelProvider::PANEL;
+        return $panel->getId() === AdminPanelProvider::PANEL;
     }
 
     protected $fillable = [
@@ -37,9 +40,4 @@ class Operator extends Authenticatable implements \OwenIt\Auditing\Contracts\Aud
         'email_verified_at' => 'datetime',
         'password'          => 'hashed',
     ];
-
-    public function tenants(): HasMany
-    {
-        return $this->hasMany(Tenant::class);
-    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Providers\Filament\AccountPanelProvider;
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Panel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -12,7 +13,6 @@ use Laravel\Sanctum\HasApiTokens;
 use OwenIt\Auditing\Auditable;
 use Rappasoft\LaravelAuthenticationLog\Traits\AuthenticationLoggable;
 use Spatie\Permission\Traits\HasRoles;
-use Stancl\Tenancy\Middleware\InitializeTenancyByDomain;
 
 class User extends Authenticatable implements \OwenIt\Auditing\Contracts\Auditable, FilamentUser
 {
@@ -23,32 +23,22 @@ class User extends Authenticatable implements \OwenIt\Auditing\Contracts\Auditab
         HasRoles,
         Notifiable;
 
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array<int, string>
-     */
+    public function canAccessPanel(Panel $panel): bool
+    {
+        return $panel->getId() === AccountPanelProvider::PANEL;
+    }
+
     protected $fillable = [
         'name',
         'email',
         'password',
     ];
 
-    /**
-     * The attributes that should be hidden for serialization.
-     *
-     * @var array<int, string>
-     */
     protected $hidden = [
         'password',
         'remember_token',
     ];
 
-    /**
-     * The attributes that should be cast.
-     *
-     * @var array<string, string>
-     */
     protected $casts = [
         'email_verified_at' => 'datetime',
         'password'          => 'hashed',
@@ -57,13 +47,5 @@ class User extends Authenticatable implements \OwenIt\Auditing\Contracts\Auditab
     public function tenants(): HasMany
     {
         return $this->hasMany(Tenant::class);
-    }
-
-    public function canAccessPanel(Panel $panel): bool
-    {
-        $tenant_context = in_array(InitializeTenancyByDomain::class, $panel->getMiddleware());
-        $tenant         = tenant('id') !== null;
-
-        return ($tenant_context && $tenant) || (! $tenant_context && ! $tenant);
     }
 }

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Providers\Filament;
+
+use Filament\Http\Middleware\Authenticate;
+use Filament\Http\Middleware\DisableBladeIconComponents;
+use Filament\Http\Middleware\DispatchServingFilamentEvent;
+use Filament\Pages;
+use Filament\Panel;
+use Filament\PanelProvider;
+use Filament\Support\Colors\Color;
+use Filament\Widgets;
+use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
+use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
+use Illuminate\Routing\Middleware\SubstituteBindings;
+use Illuminate\Session\Middleware\AuthenticateSession;
+use Illuminate\Session\Middleware\StartSession;
+use Illuminate\View\Middleware\ShareErrorsFromSession;
+
+/**
+ * Class AdminPanelProvider
+ */
+class AdminPanelProvider extends PanelProvider
+{
+    public const PANEL = 'admin';
+
+    public function panel(Panel $panel): Panel
+    {
+        return $panel
+            ->id(self::PANEL)
+            ->path(self::PANEL)
+            ->login()
+            ->authGuard(self::PANEL)
+            ->colors([
+                'primary' => Color::Amber,
+            ])
+            ->discoverResources(in: app_path('Filament/'.ucfirst(self::PANEL).'/Resources'),
+                for: 'App\\Filament\\'.ucfirst(self::PANEL).'\\Resources')
+            ->discoverPages(in: app_path('Filament/'.ucfirst(self::PANEL).'/Pages'),
+                for: 'App\\Filament\\'.ucfirst(self::PANEL).'\\Pages')
+            ->pages([
+                Pages\Dashboard::class,
+            ])
+            ->discoverWidgets(in: app_path('Filament/'.ucfirst(self::PANEL).'/Widgets'),
+                for: 'App\\Filament\\'.ucfirst(self::PANEL).'\\Widgets')
+            ->widgets([
+                Widgets\AccountWidget::class,
+                Widgets\FilamentInfoWidget::class,
+            ])
+            ->middleware([
+                EncryptCookies::class,
+                AddQueuedCookiesToResponse::class,
+                StartSession::class,
+                AuthenticateSession::class,
+                ShareErrorsFromSession::class,
+                VerifyCsrfToken::class,
+                SubstituteBindings::class,
+                DisableBladeIconComponents::class,
+                DispatchServingFilamentEvent::class,
+            ])
+            ->authMiddleware([
+                Authenticate::class,
+            ]);
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -173,6 +173,7 @@ return [
         App\Providers\TelescopeServiceProvider::class,
         App\Providers\Filament\AccountPanelProvider::class,
         App\Providers\Filament\OperatePanelProvider::class,
+        App\Providers\Filament\AdminPanelProvider::class,
     ])->toArray(),
 
     /*

--- a/config/auth.php
+++ b/config/auth.php
@@ -52,6 +52,10 @@ return [
             'driver'   => 'session',
             'provider' => 'operators',
         ],
+        'admin' => [
+            'driver'   => 'session',
+            'provider' => 'admin',
+        ],
     ],
 
     /*
@@ -79,6 +83,10 @@ return [
         'operators' => [
             'driver' => 'eloquent',
             'model'  => App\Models\Operator::class,
+        ],
+        'admin' => [
+            'driver' => 'eloquent',
+            'model'  => App\Models\Administrator::class,
         ],
     ],
 

--- a/database/migrations/2024_01_07_195434_create_administrators_table.php
+++ b/database/migrations/2024_01_07_195434_create_administrators_table.php
@@ -4,7 +4,8 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class extends Migration
+{
     public function up(): void
     {
         Schema::create('administrators', function (Blueprint $table) {

--- a/database/migrations/2024_01_07_195434_create_administrators_table.php
+++ b/database/migrations/2024_01_07_195434_create_administrators_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('administrators', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->timestamp('email_verified_at')->nullable();
+            $table->string('password');
+            $table->rememberToken();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('administrators');
+    }
+};


### PR DESCRIPTION
The previous "admin" panel was user-facing, so has been redesignated in a recent commit as "account" so that the URL would better reflect its purpose: subscription management. 

This left a gap that I intended to fill with a Control Plane panel called Control. That unfortunately led me to a new user type that would have been called a Controller, which posed risk of confusion given the MVC framework in use. 

So I've added a **new** panel called 'admin', reachable at /admin. The user type & model for this panel are Administrator and the auth guard and driver are 'admin'. 

To capture the folder hierarchy, I created a filament resource called Administrator. Given that registration is disabled on the admin panel for clear reasons, we'll need a way to manage Admin users. This begins the stub-out of that work. 