### PR TITLE
Improve Test Coverage: Domains Service & Panel Generation

### DIFF
--- a/app/Facades/Domains.php
+++ b/app/Facades/Domains.php
@@ -8,6 +8,9 @@ class Domains extends Facade
 {
     protected static function getFacadeAccessor(): string
     {
-        return 'nexus.domains';
+
+        // Testing pint hook
+
+                              return 'nexus.domains';
     }
 }

--- a/app/Facades/Domains.php
+++ b/app/Facades/Domains.php
@@ -8,9 +8,6 @@ class Domains extends Facade
 {
     protected static function getFacadeAccessor(): string
     {
-        // Testing pint hook
-
         return 'nexus.domains';
-
     }
 }

--- a/app/Facades/Domains.php
+++ b/app/Facades/Domains.php
@@ -8,9 +8,9 @@ class Domains extends Facade
 {
     protected static function getFacadeAccessor(): string
     {
-
         // Testing pint hook
 
-                              return 'nexus.domains';
+        return 'nexus.domains';
+
     }
 }

--- a/setup.sh
+++ b/setup.sh
@@ -110,11 +110,11 @@ if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
     cat > .git/hooks/pre-commit <<EOF
 #!/bin/sh
 
-# Run Pint to fix code style issues
-./vendor/bin/sail exec -T ./vendor/bin/pint
+files=$(git diff --cached --name-only --diff-filter=ACM -- '*.php');
 
-# Continue with the commit if no changes were made
-exit 0
+./vendor/bin/sail exec -T laravel.test ./vendor/bin/pint $files -q
+
+git add $files
 EOF
 
     chmod +x .git/hooks/pre-commit || error_exit "Error setting pre-commit hook as executable."

--- a/tests/Feature/ServicesDomainsTest.php
+++ b/tests/Feature/ServicesDomainsTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use App\Services\Domains;
+
+beforeEach(function () {
+    $this->domains = new Domains();
+    $this->domain = 'example.com';
+});
+
+it('can add a domain to the dns provider', function () {
+    $this->domains->addToNameserver($this->domain);
+})->expectNotToPerformAssertions();
+
+it('can remove a domain from the dns provider', function () {
+    $this->domains->removeFromNameserver($this->domain);
+})->expectNotToPerformAssertions();
+
+it('can check to see if a domain exists in the dns provider', function () {
+    $this->domains->existsInNameserver($this->domain);
+})->expectNotToPerformAssertions();

--- a/tests/Feature/ServicesDomainsTest.php
+++ b/tests/Feature/ServicesDomainsTest.php
@@ -4,7 +4,7 @@ use App\Services\Domains;
 
 beforeEach(function () {
     $this->domains = new Domains();
-    $this->domain = 'example.com';
+    $this->domain  = 'example.com';
 });
 
 it('can add a domain to the dns provider', function () {

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -1,5 +1,0 @@
-<?php
-
-test('that true is true', function () {
-    expect(true)->toBeTrue();
-});

--- a/tests/Unit/NexusCustomBrandingTest.php
+++ b/tests/Unit/NexusCustomBrandingTest.php
@@ -11,7 +11,7 @@
 
 use App\Services\Colors;
 
-test('that filament colors are compatible with custom branding', function () {
+it('has colors that are compatible with custom branding', function () {
 
     $colors = new Colors();
 

--- a/tests/Unit/NexusPanelProviderTest.php
+++ b/tests/Unit/NexusPanelProviderTest.php
@@ -8,17 +8,15 @@
  * If this test sequence fails, it means that the stub file has been updated and
  * we need to update our replacement logic in app/Console/Commands/NexusMakePanel.php
  */
-
-$stubFilePath = 'vendor/filament/support/stubs/PanelProvider.stub';
+$stubFilePath    = 'vendor/filament/support/stubs/PanelProvider.stub';
 $stubFileContent = file_get_contents($stubFilePath);
-
 
 it('has a filament panel provider stub file', function () use ($stubFilePath) {
 
     $this->assertTrue(file_exists($stubFilePath));
 });
 
-it('has the necessary strings in place for us to find & replace', function() use ($stubFileContent) {
+it('has the necessary strings in place for us to find & replace', function () use ($stubFileContent) {
     $find = [
         'App\\\\Filament\\\\{{ directory }}\\\\Resources',
         'App\\\\Filament\\\\{{ directory }}\\\\Pages',
@@ -31,7 +29,7 @@ it('has the necessary strings in place for us to find & replace', function() use
     }
 });
 
-it("looks like a default panel provider stub (not already nexus-replaced)", function() use ($stubFileContent) {
+it('looks like a default panel provider stub (not already nexus-replaced)', function () use ($stubFileContent) {
     $find = [
         '# Custom Branding Goes Here',
         'PreventAccessFromCentralDomains::class',

--- a/tests/Unit/NexusPanelProviderTest.php
+++ b/tests/Unit/NexusPanelProviderTest.php
@@ -7,11 +7,17 @@
  *
  * If this test sequence fails, it means that the stub file has been updated and
  * we need to update our replacement logic in app/Console/Commands/NexusMakePanel.php
+ *
+ * Troubleshooting: delete the vendor/ folder and re-run composer install. If that
+ * doesn't work, we've probably encountered a breaking change in Filament. We'll
+ * need to update the stub file and the stub manipulation logic found in our
+ * NexusMakePanelProviderStub.php file.
  */
+
 $stubFilePath    = 'vendor/filament/support/stubs/PanelProvider.stub';
 $stubFileContent = file_get_contents($stubFilePath);
 
-it('has a filament panel provider stub file', function () use ($stubFilePath) {
+it('has the stub file in the right location', function () use ($stubFilePath) {
 
     $this->assertTrue(file_exists($stubFilePath));
 });
@@ -29,7 +35,7 @@ it('has the necessary strings in place for us to find & replace', function () us
     }
 });
 
-it('looks like a default panel provider stub (not already nexus-replaced)', function () use ($stubFileContent) {
+it('looks like a new stub', function () use ($stubFileContent) {
     $find = [
         '# Custom Branding Goes Here',
         'PreventAccessFromCentralDomains::class',

--- a/tests/Unit/NexusPanelProviderTest.php
+++ b/tests/Unit/NexusPanelProviderTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This ensures that Filament panel provider stub exists and contains the necessary
+ * pieces for us to perform string replacement, so we can customize the panel with
+ * details needed for Nexus operations.
+ *
+ * If this test sequence fails, it means that the stub file has been updated and
+ * we need to update our replacement logic in app/Console/Commands/NexusMakePanel.php
+ */
+
+$stubFilePath = 'vendor/filament/support/stubs/PanelProvider.stub';
+$stubFileContent = file_get_contents($stubFilePath);
+
+
+it('has a filament panel provider stub file', function () use ($stubFilePath) {
+
+    $this->assertTrue(file_exists($stubFilePath));
+});
+
+it('has the necessary strings in place for us to find & replace', function() use ($stubFileContent) {
+    $find = [
+        'App\\\\Filament\\\\{{ directory }}\\\\Resources',
+        'App\\\\Filament\\\\{{ directory }}\\\\Pages',
+        'App\\\\Filament\\\\{{ directory }}\\\\Widgets',
+        '{{ class }}',
+        '{{ id }}',
+    ];
+    foreach ($find as $string) {
+        $this->assertStringContainsString($string, $stubFileContent);
+    }
+});
+
+it("looks like a default panel provider stub (not already nexus-replaced)", function() use ($stubFileContent) {
+    $find = [
+        '# Custom Branding Goes Here',
+        'PreventAccessFromCentralDomains::class',
+        'InitializeTenancyByDomain::class',
+        'Jeffgreco13\FilamentBreezy\BreezyCore',
+        'public function register(): void',
+    ];
+    foreach ($find as $string) {
+        $this->assertStringNotContainsString($string, $stubFileContent);
+    }
+});

--- a/tests/Unit/NexusPanelProviderTest.php
+++ b/tests/Unit/NexusPanelProviderTest.php
@@ -13,7 +13,6 @@
  * need to update the stub file and the stub manipulation logic found in our
  * NexusMakePanelProviderStub.php file.
  */
-
 $stubFilePath    = 'vendor/filament/support/stubs/PanelProvider.stub';
 $stubFileContent = file_get_contents($stubFilePath);
 


### PR DESCRIPTION
Adds tests to improve coverage... 

The Domains Service is largely unused but there are plans for it. This puts some scaffolding in place around it; primary mission here is to ensure that the methods don't throw exceptions when called. We'll need to update this test as we proceed with implementation logic. 

The Panel Generation logic in Nexus relies on the existence of a Stub file, and for certain strings to exist in that stub file. This test ensures that we're looking at a valid stub (it exists, it has the strings we search for, and it doesn't have strings that would indicate we're looking at an already-replaced file -- which would cause problems for the user). 