### PR TITLE
Pulse Now Supports Multiple User Types

### DIFF
--- a/app/Console/Commands/NexusMakePanel.php
+++ b/app/Console/Commands/NexusMakePanel.php
@@ -58,6 +58,8 @@ class NexusMakePanel extends Command
 
             $this->call('nexus:make-panel-user-model', $modelAndTenant);
 
+            $this->call('nexus:make-panel-user-pulse-resolver', $modelAndTenant);
+
             $this->call('nexus:make-panel-user-migration', $modelAndTenant);
 
             $this->call('nexus:make-auth-guard-and-provider', $modelAndTenant);

--- a/app/Console/Commands/NexusMakePanelUserPulseResolver.php
+++ b/app/Console/Commands/NexusMakePanelUserPulseResolver.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\Nexus;
+use Exception;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+
+class NexusMakePanelUserPulseResolver extends Command
+{
+    protected $signature = 'nexus:make-panel-user-pulse-resolver {model} {--tenant}';
+
+    protected $description = 'Create a Pulse resolver for a panel user model.';
+
+    protected static string $resolverFileDir = 'storage/app/nexus/pulse/';
+
+    protected static string $resolverFilePathOld = 'storage/app/nexus/pulse/UserResolver.php.old';
+
+    public function handle(): void
+    {
+        $resolverPath  = app_path('Pulse/UserResolver.php');
+        $commentAnchor = '// do-not-remove-nexus-user-resolver-load-goes-here';
+
+        Nexus::backupFile($resolverPath);
+
+        try {
+
+            if (file_exists($resolverPath)) {
+
+                $model         = $this->argument('model');
+                $tenant        = (bool) $this->option('tenant');
+                $tenantPath    = $tenant ? 'Tenant\\' : '';
+                $modelClass    = "App\\Models\\{$tenantPath}{$model}";
+                $modelClassRef = "$model::class";
+                $modelText     = "$modelClassRef => $model::findMany(\$keys
+                ->filter(fn (\$key) => \$key[0] === $modelClassRef)->map(fn (\$key) => \$key[1])->values()),";
+
+                $this->info("Creating Pulse resolver for $modelClass...");
+
+                $useStatementAnchor = 'use Laravel\Pulse\Contracts\ResolvesUsers;';
+
+                $readFile = File::get($resolverPath);
+
+                if (Str::contains($readFile, $modelClass)) {
+                    throw new Exception("Resolver for $modelClass already exists. Have you already run this command?");
+                }
+
+                if (! Str::contains($readFile, $useStatementAnchor)) {
+                    throw new Exception("Missing the use statement anchor. Without that use statement, we don't know where to put our own.");
+                }
+
+                if (! Str::contains($readFile, $commentAnchor)) {
+                    throw new Exception('Missing the comment anchor. This tells us where to place the new resolvers.');
+                }
+
+                $this->replaceInFile(
+                    search: $useStatementAnchor,
+                    replace: "use $modelClass;\n$useStatementAnchor",
+                    path: $resolverPath);
+
+                $this->replaceInFile(
+                    search: $commentAnchor,
+                    replace: $modelText.PHP_EOL.PHP_EOL.'            '.$commentAnchor.PHP_EOL,
+                    path: $resolverPath
+                );
+
+                $userMappingText  = "User::class         => 'User',";
+                $modelMappingText = "$modelClassRef          => '$model',";
+
+                $this->replaceInFile(
+                    search: $userMappingText,
+                    replace: $modelMappingText.PHP_EOL.'            '.$userMappingText,
+                    path: $resolverPath
+                );
+
+            }
+        } catch (Exception $e) {
+            $this->error($e->getMessage());
+            Nexus::restoreFile($resolverPath);
+        }
+
+    }
+
+    protected function replaceInFile(string $search, string $replace, string $path): void
+    {
+        $contents = File::get($path);
+        $contents = str_replace($search, $replace, $contents);
+        File::put($path, $contents);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Pulse\UserResolver;
 use App\Services\Colors;
 use App\Services\Domains;
 use App\Services\Environment;
@@ -11,6 +12,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Pulse\Users;
 use Laravel\Telescope\TelescopeServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -31,6 +33,7 @@ class AppServiceProvider extends ServiceProvider
         $this->setFacades();
         $this->setModelOptions();
         $this->setSanctumGuard();
+        $this->app->bind(Users::class, UserResolver::class);
     }
 
     protected function registerNonProdServiceProviders(): void

--- a/app/Pulse/UserResolver.php
+++ b/app/Pulse/UserResolver.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Pulse;
+
+use App\Models\Administrator;
+use App\Models\User;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Support\Collection;
+use Laravel\Pulse\Contracts\ResolvesUsers;
+
+class UserResolver implements ResolvesUsers
+{
+    protected array $resolvedUsers;
+
+    public function load(Collection $keys): self
+    {
+        $keys = $keys->map(fn ($key) => explode(':', $key));
+
+        $this->resolvedUsers = [
+
+            Administrator::class => Administrator::findMany($keys
+                ->filter(fn ($key) => $key[0] === Administrator::class)->map(fn ($key) => $key[1])->values()),
+
+            // do-not-remove-nexus-user-resolver-load-goes-here
+
+            User::class => User::findMany($keys
+                ->filter(fn ($key) => $key[0] === User::class)->map(fn ($key) => $key[1])->values()),
+
+        ];
+
+        return $this;
+
+    }
+
+    public function find(int|string|null $key): object
+    {
+
+        [$class, $id] = explode(':', $key);
+
+        $user = $this->resolvedUsers[$class]->first(
+            fn ($user) => $user->id == $id
+        );
+
+        return $this->getProfile($user);
+    }
+
+    /**
+     * All Nexus user types extend this User model. We use this to get the necessary
+     * panel detail.
+     */
+    protected function getProfile(\Illuminate\Foundation\Auth\User $user): object
+    {
+        return (object) [
+            'name'  => $user->name,
+            'extra' => $user->email,
+        ];
+
+    }
+
+    public function key(Authenticatable $user): int|string|null
+    {
+
+        return get_class($user).':'.$user->getAuthIdentifier();
+
+    }
+}

--- a/app/Services/Nexus.php
+++ b/app/Services/Nexus.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\File;
 
 use function Laravel\Prompts\select;
 use function Laravel\Prompts\text;
@@ -127,5 +128,27 @@ class Nexus
         }
 
         return $firstWords;
+    }
+
+    public static function getBackupStorageDirectory(): string
+    {
+        return storage_path('app/nexus/backup/');
+    }
+
+    public static function backupFile(string $originalPath): void
+    {
+        $backupPath = self::getBackupStorageDirectory().$originalPath;
+        $backupDir  = dirname($backupPath);
+        File::isDirectory($backupDir) || File::makeDirectory($backupDir, 0755, true, true);
+
+        File::copy($originalPath, $backupPath);
+    }
+
+    public static function restoreFile(string $backupPath): void
+    {
+        if (File::exists($backupPath)) {
+            $originalPath = str_replace(self::getBackupStorageDirectory(), '', $backupPath);
+            File::copy($backupPath, $originalPath);
+        }
     }
 }


### PR DESCRIPTION
Create a pulse user resolver and an artisan command for extending the user resolver
with newly-created panel authenticable types (user, manager, admin, etc). 
